### PR TITLE
Fix vozdeckyl dev bubble pointers

### DIFF
--- a/src/tools/circlecount/circlecounttool.cpp
+++ b/src/tools/circlecount/circlecounttool.cpp
@@ -4,6 +4,7 @@
 #include "circlecounttool.h"
 #include "colorutils.h"
 #include <QPainter>
+#include <QPainterPath>
 
 namespace {
 #define PADDING_VALUE 2

--- a/src/utils/screengrabber.cpp
+++ b/src/utils/screengrabber.cpp
@@ -108,6 +108,12 @@ QPixmap ScreenGrabber::grabEntireDesktop(bool& ok)
             }
             default:
                 ok = false;
+                AbstractLogger::error()
+                  << tr("Unable to detect desktop environment (GNOME? KDE? "
+                        "Sway? ...)");
+                AbstractLogger::error()
+                  << tr("Hint: try setting the XDG_CURRENT_DESKTOP environment "
+                        "variable.");
                 break;
         }
         if (!ok) {

--- a/src/widgets/capture/selectionwidget.cpp
+++ b/src/widgets/capture/selectionwidget.cpp
@@ -203,14 +203,17 @@ void SelectionWidget::parentMouseMoveEvent(QMouseEvent* e)
         mouseSide = getMouseSide(e->pos());
     }
 
+    QPoint pos;
+
     if (!isVisible() || !mouseSide) {
         show();
-        m_dragStartPos = e->pos();
         m_activeSide = TOPLEFT_SIDE;
-        setGeometry({ e->pos(), e->pos() });
+        pos = m_dragStartPos;
+        setGeometry({ pos, pos });
+    } else {
+        pos = e->pos();
     }
 
-    QPoint pos = e->pos();
     auto geom = geometry();
     bool symmetryMod = qApp->keyboardModifiers() & Qt::ShiftModifier;
 
@@ -280,7 +283,7 @@ void SelectionWidget::parentMouseMoveEvent(QMouseEvent* e)
         setGeometry(geom.normalized());
         m_activeSide = getProperSide(m_activeSide, geom);
     }
-    m_dragStartPos = pos;
+    m_dragStartPos = e->pos();
 }
 
 void SelectionWidget::paintEvent(QPaintEvent*)


### PR DESCRIPTION
While compiling I got this error:

```console
[ 84%] Building CXX object src/CMakeFiles/flameshot.dir/tools/launcher/launcheritemdelegate.cpp.o
/home/mehrad/tmp/tobedeleted/vozdeckyl_flameshot/src/tools/circlecount/circlecounttool.cpp: In member function ‘virtual void CircleCountTool::process(QPainter&, const QPixmap&)’:
/home/mehrad/tmp/tobedeleted/vozdeckyl_flameshot/src/tools/circlecount/circlecounttool.cpp:124:22: error: aggregate ‘QPainterPath path’ has incomplete type and cannot be defined
124 |         QPainterPath path;
|                      ^~~~
[ 85%] Building CXX object src/CMakeFiles/flameshot.dir/tools/launcher/openwithprogram.cpp.o
```

which suggested that you have missed to include <QPainterPath> . 